### PR TITLE
Fixed: libssl prompting showing an interactive prompt, making it impossible to provision the machine.

### DIFF
--- a/vagrant_setup.sh
+++ b/vagrant_setup.sh
@@ -1,57 +1,59 @@
 #!/bin/bash
 
+export DEBIAN_FRONTEND=noninteractive
+export UCF_FORCE_CONFOLD=1
 
 # Updates
-sudo apt-get -y update
-sudo apt-get -y upgrade
+sudo -E apt-get -y update
+sudo -E apt-get -y upgrade
 
-sudo apt-get -y install python3-pip
-sudo apt-get -y install gdb gdb-multiarch
-sudo apt-get -y install unzip
-sudo apt-get -y install foremost
-sudo apt-get -y install htop
-sudo apt-get -y install terminator
+sudo -E apt-get -y install python3-pip
+sudo -E apt-get -y install gdb gdb-multiarch
+sudo -E apt-get -y install unzip
+sudo -E apt-get -y install foremost
+sudo -E apt-get -y install htop
+sudo -E apt-get -y install terminator
 
 # install GUI
-sudo apt-get -y install ubuntu-desktop
-sudo apt-get -y install virtualbox-guest-dkms
-sudo apt-get -y install virtualbox-guest-utils
-sudo apt-get -y install virtualbox-guest-x11
-sudo sed -i 's/allowed_users=.*$/allowed_users=anybody/' /etc/X11/Xwrapper.config
-#config.vm.provision "shell", inline: "sudo apt-get install -y lightdm lightdm-gtk-greeter
+sudo -E apt-get -y install ubuntu-desktop
+sudo -E apt-get -y install virtualbox-guest-dkms
+sudo -E apt-get -y install virtualbox-guest-utils
+sudo -E apt-get -y install virtualbox-guest-x11
+sudo -E sed -i 's/allowed_users=.*$/allowed_users=anybody/' /etc/X11/Xwrapper.config
+#config.vm.provision "shell", inline: "sudo -E apt-get install -y lightdm lightdm-gtk-greeter
 
 # Remove amazon from GUI
-sudo apt purge -y ubuntu-web-launchers
+sudo -E apt purge -y ubuntu-web-launchers
 
 # Install Java for ghidra
-sudo add-apt-repository ppa:linuxuprising/java
-sudo apt-get update
-echo oracle-java11-installer shared/accepted-oracle-license-v1-2 select true | sudo /usr/bin/debconf-set-selections
-sudo apt-get -y install oracle-java11-installer
+sudo -E add-apt-repository ppa:linuxuprising/java
+sudo -E apt-get update
+echo oracle-java11-installer shared/accepted-oracle-license-v1-2 select true | sudo -E /usr/bin/debconf-set-selections
+sudo -E apt-get -y install oracle-java11-installer
 
 
 # Install ARM/MIPS support - https://ownyourbits.com/2018/06/13/transparently-running-binaries-from-any-architecture-in-linux-with-qemu-and-binfmt_misc/
-sudo apt-get -y install gcc-arm-linux-gnueabihf
-sudo apt-get -y install qemu qemu-user qemu-user-static
-sudo apt-get -y install debian-keyring
-sudo apt-get -y install debian-archive-keyring
-sudo apt-get -y install libc6-armel-cross libc6-dev-armel-cross binutils-arm-linux-gnueabi libncurses5-dev
-sudo apt-get -y install libc6-mipsel-cross
-sudo apt-get -y install libc6-arm64-cross libc6-armhf-cross libc6-armel-armhf-cross libc6-armel-cross libc6-armhf-armel-cross
+sudo -E apt-get -y install gcc-arm-linux-gnueabihf
+sudo -E apt-get -y install qemu qemu-user qemu-user-static
+sudo -E apt-get -y install debian-keyring
+sudo -E apt-get -y install debian-archive-keyring
+sudo -E apt-get -y install libc6-armel-cross libc6-dev-armel-cross binutils-arm-linux-gnueabi libncurses5-dev
+sudo -E apt-get -y install libc6-mipsel-cross
+sudo -E apt-get -y install libc6-arm64-cross libc6-armhf-cross libc6-armel-armhf-cross libc6-armel-cross libc6-armhf-armel-cross
 echo "export QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf" >> /home/vagrant/.zshrc
 
 
 
 
 # These are so the 64 bit vm can build 32 bit
-sudo apt-get -y install libx32gcc-4.8-dev
-sudo apt-get -y install libc6-dev-i386
+sudo -E apt-get -y install libx32gcc-4.8-dev
+sudo -E apt-get -y install libc6-dev-i386
 
 
 # Install Pwntools
-sudo apt-get -y install python2.7 python-pip python-dev git libssl-dev libffi-dev build-essential
-sudo -H pip install --upgrade pip
-sudo -H pip install --upgrade pwntools
+sudo -E apt-get -y install python2.7 python-pip python-dev git libssl-dev libffi-dev build-essential
+sudo -E -H pip install --upgrade pip
+sudo -E -H pip install --upgrade pwntools
 
 
 
@@ -60,7 +62,7 @@ mkdir tools
 cd tools
 
 # Install capstone
-sudo apt-get install libcapstone-dev
+sudo -E apt-get install libcapstone-dev
 
 # Install pwndbg
 git clone https://github.com/zachriggle/pwndbg
@@ -68,7 +70,7 @@ cd pwndbg
 ./setup.sh
 
 # Install pwndbg for root
-sudo su << HERE
+sudo -E su << HERE
 git clone https://github.com/zachriggle/pwndbg
 cd pwndbg
 ./setup.sh
@@ -76,38 +78,38 @@ HERE
 
 
 # pycparser for pwndbg
-sudo -H pip3 install pycparser # Use pip3 for Python3
+sudo -E -H pip3 install pycparser # Use pip3 for Python3
 
 # Install binwalk
 cd tools
 git clone https://github.com/devttys0/binwalk
 cd binwalk
-sudo python setup.py install
+sudo -E python setup.py install
 
 # Install Firmware-Mod-Kit
-sudo apt-get -y install git build-essential zlib1g-dev liblzma-dev python-magic
+sudo -E apt-get -y install git build-essential zlib1g-dev liblzma-dev python-magic
 cd ~/tools
 git clone https://github.com/rampageX/firmware-mod-kit.git
 
 
 # oh-my-zsh
-sudo apt-get -y install zsh
+sudo -E apt-get -y install zsh
 echo vagrant | sh -c "$(wget https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh -O -)"
 
 # Install Angr
 cd /home/vagrant/tools
-sudo apt-get -y install python-dev libffi-dev build-essential virtualenvwrapper
-sudo -H pip install virtualenv
+sudo -E apt-get -y install python-dev libffi-dev build-essential virtualenvwrapper
+sudo -E -H pip install virtualenv
 virtualenv angr
 source angr/bin/activate
 pip install angr --upgrade
 
 
 # Enable 32bit binaries on 64bit host
-sudo dpkg --add-architecture i386
-sudo apt-get -y update
-sudo apt-get -y upgrade
-sudo apt-get -y install libc6:i386 libc6-dbg:i386 libncurses5:i386 libstdc++6:i386
+sudo -E dpkg --add-architecture i386
+sudo -E apt-get -y update
+sudo -E apt-get -y upgrade
+sudo -E apt-get -y install libc6:i386 libc6-dbg:i386 libncurses5:i386 libstdc++6:i386
 
 
 # Install z3 theorem prover
@@ -116,26 +118,26 @@ sudo apt-get -y install libc6:i386 libc6-dbg:i386 libncurses5:i386 libstdc++6:i3
 #python scripts/mk_make.py
 #cd build
 #make
-#sudo make install
+#sudo -E make install
 
 
 # Install binary ninja
 mkdir /home/vagrant/tools/binaryninja
 
 # Install sublime
-wget -qO - https://download.sublimetext.com/sublimehq-pub.gpg | sudo apt-key add -
-sudo apt-add-repository "deb https://download.sublimetext.com/ apt/stable/"
-sudo apt-get update
-sudo apt-get -y install libgtk2.0-0
-sudo apt-get -y install sublime-text
+wget -qO - https://download.sublimetext.com/sublimehq-pub.gpg | sudo -E apt-key add -
+sudo -E apt-add-repository "deb https://download.sublimetext.com/ apt/stable/"
+sudo -E apt-get update
+sudo -E apt-get -y install libgtk2.0-0
+sudo -E apt-get -y install sublime-text
 mkdir -p /home/vagrant/.config/sublime-text-3/Local
 
 # Install chromium
-sudo apt-get install -y chromium-browser
+sudo -E apt-get install -y chromium-browser
 
 # Install one_gadget
-sudo apt install ruby-full
-sudo gem install one_gadget
+sudo -E apt install ruby-full
+sudo -E gem install one_gadget
 
 # Add ghidra alias
 echo "alias ghidra='/home/vagrant/tools/ghidra_9.0/ghidraRun'" >> /home/vagrant/.zshrc


### PR DESCRIPTION
Using `sudo -E` we preserve the environment variables `DEBIAN_FRONTEND=noninteractive, UCF_FORCE_CONFOLD=1`. This makes sure apt doesn't prompt us for something (which we can't select when provisioning).